### PR TITLE
Add classes to init

### DIFF
--- a/mutis/__init__.py
+++ b/mutis/__init__.py
@@ -5,7 +5,12 @@ from . import correlation
 from . import signal
 from . import utils
 
-__all__ = ["__version__"]
+__all__ = [
+    "correlation",
+    "signal",
+    "utils",
+    "__version__",
+]
 
 import pkg_resources
 

--- a/mutis/__init__.py
+++ b/mutis/__init__.py
@@ -1,6 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE
 """MUTIS: A Python package for muti-wavelength time series analysis."""
 
+from . import correlation
+from . import signal
+from . import utils
+
 __all__ = ["__version__"]
 
 import pkg_resources
@@ -10,3 +14,5 @@ try:
 except pkg_resources.DistributionNotFound:
     # package is not installed
     pass
+
+


### PR DESCRIPTION
Classes were missing from `__init__.py` and they could not be loaded.